### PR TITLE
Improved metadata for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "syntactic-for"
 version = "0.1.0"
 edition = "2021"
-license-file = "LICENSE"
+license = "MIT"
+readme = "README.md"
 description = "A syntactic 'for' loop macro"
 repository = "https://github.com/xlambein/syntactic-for"
 keywords = ["macro"]


### PR DESCRIPTION
`license-file` makes crates.io think it's a custom license, so `license` is better. And `readme` copies the readme over to the crate page on crates.io.